### PR TITLE
Fix V3008

### DIFF
--- a/Engine/Chips/Game/GameChip.cs
+++ b/Engine/Chips/Game/GameChip.cs
@@ -269,7 +269,7 @@ namespace PixelVisionSDK.Chips
             if ((data & CachedData.TilemapSize) == CachedData.TilemapSize)
             {
                 tilemapSizeCached.x = tilemapChip.columns;
-                tilemapSizeCached.x = tilemapChip.rows;
+                tilemapSizeCached.y = tilemapChip.rows;
             }
 
         }


### PR DESCRIPTION
Hello! I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio:

- The 'tilemapSizeCached.x' variable is assigned values twice successively. Perhaps this is a mistake. Check lines: 272, 271. GameChip.cs 272