### PR TITLE
Add support for mouse scroll wheel, middle click, and Xbutton1/Xbutton2

### DIFF
--- a/SDK/Engine/Chips/Game/GameChip.cs
+++ b/SDK/Engine/Chips/Game/GameChip.cs
@@ -1243,6 +1243,24 @@ namespace PixelVision8.Engine.Chips
         }
 
         /// <summary>
+        ///     The MouseWheel() method returns an int for how far the scroll wheel has moved since the last frame.
+        ///     This value is read-only. Generally speaking, one "tick" of the scroll wheel is 120.
+        ///     The returned value is positive for up, and negative for down.
+        /// </summary>
+        /// <param name="direction">
+        ///     Optional ScrollDirection enum. Uses ScrollDirection.Vertical by default.
+        ///     Determines whether to detect vertical or horizontal scrolling.
+        /// </param>
+        /// <returns>
+        ///     Returns an int for how far the scroll wheel has moved since the last frame.
+        /// </returns>
+        /// 
+        public int MouseWheel(ScrollDirection direction = ScrollDirection.Vertical)
+        {
+            return controllerChip.ReadMouseWheel(direction);
+        }
+
+        /// <summary>
         ///     The InputString() method returns the keyboard input entered this frame. This method is
         ///     useful for capturing keyboard text input.
         /// </summary>

--- a/SDK/Engine/Chips/Game/LuaGameChip.cs
+++ b/SDK/Engine/Chips/Game/LuaGameChip.cs
@@ -156,6 +156,7 @@ namespace PixelVision8.Engine.Chips
             luaScript.Globals["Button"] = new Func<Buttons, InputState, int, bool>(Button);
             luaScript.Globals["MouseButton"] = new Func<int, InputState, bool>(MouseButton);
             luaScript.Globals["MousePosition"] = new Func<Point>(MousePosition);
+            luaScript.Globals["MouseWheel"] = new Func<ScrollDirection, int>(MouseWheel);
             luaScript.Globals["InputString"] = new Func<string>(InputString);
 
             #endregion
@@ -269,6 +270,9 @@ namespace PixelVision8.Engine.Chips
 
             UserData.RegisterType<InputState>();
             luaScript.Globals["InputState"] = UserData.CreateStatic<InputState>();
+
+            UserData.RegisterType<ScrollDirection>();
+            luaScript.Globals["ScrollDirection"] = UserData.CreateStatic<ScrollDirection>();
 
             UserData.RegisterType<SaveFlags>();
             luaScript.Globals["SaveFlags"] = UserData.CreateStatic<SaveFlags>();

--- a/SDK/Engine/Chips/Input/ControllerChip.cs
+++ b/SDK/Engine/Chips/Input/ControllerChip.cs
@@ -39,6 +39,12 @@ namespace PixelVision8.Engine.Chips
         None
     }
 
+    public enum ScrollDirection
+    {
+        Vertical,
+        Horizontal
+    }
+
     public enum InputMap
     {
         Player1UpKey,
@@ -448,9 +454,15 @@ namespace PixelVision8.Engine.Chips
                     return state.LeftButton == ButtonState.Pressed;
                 case 1:
                     return state.RightButton == ButtonState.Pressed;
+                case 2:
+                    return state.MiddleButton == ButtonState.Pressed;
+                case 3:
+                    return state.XButton1 == ButtonState.Pressed;
+                case 4:
+                    return state.XButton2 == ButtonState.Pressed;
+                default:
+                    return false;
             }
-
-            return false;
         }
 
         public bool JustPressed(Keys key)
@@ -611,6 +623,18 @@ namespace PixelVision8.Engine.Chips
             return new Point(pos.X, pos.Y);
         }
 
+        public int ReadMouseWheel(ScrollDirection direction = ScrollDirection.Vertical)
+        {
+            switch (direction)
+            {
+                case ScrollDirection.Vertical:
+                    return currentMouseState.ScrollWheelValue - previousMouseState.ScrollWheelValue;
+                case ScrollDirection.Horizontal:
+                    return currentMouseState.HorizontalScrollWheelValue - previousMouseState.HorizontalScrollWheelValue;
+                default:
+                    return 0;
+            }
+        }
 
         //        public void ConvertMousePosition(Vector pos)
         //        {

--- a/SDK/Engine/Chips/Input/IControllerChip.cs
+++ b/SDK/Engine/Chips/Input/IControllerChip.cs
@@ -32,6 +32,7 @@ namespace PixelVision8.Engine
         string ReadInputString();
         bool GetMouseButtonUp(int button);
         bool GetMouseButtonDown(int button);
+        int ReadMouseWheel(ScrollDirection direction);
         bool GetKeyUp(Keys key);
         bool GetKeyDown(Keys key);
         void MouseScale(float x, float y);


### PR DESCRIPTION
Adds a new method to the API, `MouseWheel`, that returns an integer value that reflects how much the scroll wheel has moved since the last frame. Also adds an enum, `ScrollDirection` (`Vertical` and `Horizontal`), that can be passed to `MouseWheel` to indicate the scroll axis to poll. Default is `Vertical`. Horizontal scrolling support is especially useful for gesture-based scrolling on, say, a Mac.
Also adds support to `MouseButton` for middle (3), button1/back (4) and button2/forward (5).