### PR TITLE
Fixed various song and music things

### DIFF
--- a/Disks/PixelVisionOS/System/Tools/MusicTool/code.lua
+++ b/Disks/PixelVisionOS/System/Tools/MusicTool/code.lua
@@ -799,6 +799,17 @@ function OnSelectSongField(value)
   currentSelectedSong = (value + 1) + songScrollOffset
 
   local realIndex = currentSelectedSong - songScrollOffset
+  
+  if (realIndex < 1 or realIndex > totalSongFields) then
+    local totalPatterns = #currentSongPatterns - totalSongFields
+
+    local scroll = (currentSelectedSong - 1) / totalPatterns
+    local scrollX = math.floor(scroll * songSliderData.size) + 11
+    songSliderData.handleX = scrollX
+    OnSongScroll(scroll)
+
+    realIndex = currentSelectedSong - songScrollOffset
+  end
 
   LoadLoop(tonumber(songInputFields[realIndex].text))
 
@@ -1156,7 +1167,7 @@ function Update(timeDelta)
       local currentPattern = songData["pattern"]
 
       if((currentSelectedSong - 1) ~= currentPattern and playMode ~= 3) then
-        OnSelectSongField(currentPattern)
+        OnSelectSongField(currentPattern - songScrollOffset)
         editorUI.refreshTime = 0
       end
 

--- a/Disks/PixelVisionOS/System/Tools/MusicTool/code.lua
+++ b/Disks/PixelVisionOS/System/Tools/MusicTool/code.lua
@@ -300,7 +300,7 @@ function Init()
     -- Force the slider to have a different start value so it can be updated correctly when the first song loads up
     songSliderData.value = -1
 
-    tempoStepper = editorUI:CreateNumberStepper({x = 120, y = 88}, 24, 0, 60, 480, "top", "Change the length of the pattern.")
+    tempoStepper = editorUI:CreateNumberStepper({x = 120, y = 88}, 24, 0, 1, 480, "top", "Change the length of the pattern.")
     tempoStepper.onInputAction = OnTempoChange
 
     table.insert(disableWhenPlaying, tempoStepper.backButton)

--- a/Disks/PixelVisionOS/System/Tools/MusicTool/saves.json
+++ b/Disks/PixelVisionOS/System/Tools/MusicTool/saves.json
@@ -1,23 +1,9 @@
 {
-
-"GameChip":
-{
-"savedData":{
-    "configTrack4": "4,4,6,7",
-    "configTrack3": "3,3,6,6",
-    "configTrack2": "2,2,3,4",
-    "configTrack1": "1,1,6,7",
-    "configTrack0": "0,0,6,6",
-    "configSpeedMax": "320",
-    "configSpeedMin": "120",
-    "configScale": "1",
-    "configLayering": "5",
-    "configFunk": "5",
-    "configDensity": "5",
-    "state": "0,0,17,0,0",
-    "rootDirectory": "/Workspace/MyFirstGame/",
-    "sessionID": "202004111609029716",
-    "currentBeat": "0"
-}
-}
+    
+    "GameChip":
+    {
+        "savedData":{
+            
+        }
+    }
 }

--- a/Disks/PixelVisionOS/System/Tools/TextEditorTool/saves.json
+++ b/Disks/PixelVisionOS/System/Tools/TextEditorTool/saves.json
@@ -3,12 +3,7 @@
     "GameChip":
     {
         "savedData":{
-            "scroll": "1,1",
-            "selectedSprite": "0",
-            "cursor": "1,1",
-            "rootDirectory": "/Workspace/HelloWorld/",
-            "sessionID": "202004090933276473",
-            "targetFile": "/Workspace/MyFirstGame/README.txt"
+            
         }
     }
 }

--- a/Disks/RunnerTools/BootTool/music.json
+++ b/Disks/RunnerTools/BootTool/music.json
@@ -4,7 +4,7 @@
 		"songs": [
 			{
 				"songName": "PV8",
-				"speedInBPM": 230,
+				"speedInBPM": 160,
 				"tracks":
 				[
 					{

--- a/Disks/RunnerTools/BootTool/music.json
+++ b/Disks/RunnerTools/BootTool/music.json
@@ -4,7 +4,7 @@
 		"songs": [
 			{
 				"songName": "PV8",
-				"speedInBPM": 320,
+				"speedInBPM": 230,
 				"tracks":
 				[
 					{

--- a/Runners/PixelVision8/Runner/Exporters/SongExporter.cs
+++ b/Runners/PixelVision8/Runner/Exporters/SongExporter.cs
@@ -32,15 +32,14 @@ namespace PixelVision8.Runner.Exporters
 
         // to avoid clipping, all tracks are a bit quieter since we ADD values - set to 1f for full mix
         public float mixdownTrackVolume = 0.6f;
-        public float note_tick_s = 30.0f / 120.0f; // (30.0f/120.0f) = 120BPM eighth notes
+        public float note_tick_s = 15.0f / 120.0f; // (15.0f/120.0f) = 120BPM sixteenth notes
         public float note_tick_s_odd;
 
         private readonly int[] patterns;
         private RawAudioData result;
 
 
-        public float
-            swing_rhythm_factor = 0.7f; //1.0f;//0.66666f; // how much "shuffle" - turnaround on the offbeat triplet
+        public float swing_rhythm_factor = 1.0f; //0.7f;//0.66666f; // how much "shuffle" - turnaround on the offbeat triplet
 
         private RawAudioData[] trackresult;
 
@@ -88,8 +87,7 @@ namespace PixelVision8.Runner.Exporters
 
             var totalNotesInSong = ncount; // total musical notes in song loops x notes
 
-            // TODO needed to increase this number to match the speed better but this should be test out more.
-            note_tick_s = 45.0f / songData.speedInBPM; // (30.0f/120.0f) = 120BPM eighth notes [tempo]
+            note_tick_s = 15.0f / songData.speedInBPM; // (15.0f/120.0f) = 120BPM sixteenth notes
             note_tick_s_odd = note_tick_s * swing_rhythm_factor; // small beat
 
             var notedatalength = (int) (preRenderBitrate * 2f * note_tick_s_odd); // one note worth of stereo audio (x2)
@@ -98,7 +96,6 @@ namespace PixelVision8.Runner.Exporters
             var beatlength = preRenderBitrate * note_tick_s_odd; // one note worth of time
 
             var songdatalength = notedatalength * totalNotesInSong; // stereo cd quality x song length
-
 
             var notebuffer = new float[notedatalength];
 
@@ -140,26 +137,18 @@ namespace PixelVision8.Runner.Exporters
                     // generate one note worth of audio data
                     if (gotANote > 0 && instrument[tracknum] != null)
                     {
-                        // FIXME TODO HACK: prerendered notes seem pitch shifted too high
-                        // manually fudged - WHY WHY WHY - no idea why this works, but it does.
-                        // this is the most heinous hack I've ever implemented and it hurts so bad
-                        // it isn't worth anything: this is duct tape solution
-                        var noteFUDGE = 1; //- 12; // shift how many semitones
-                        var freqFUDGE = 0.0025f; //0.005f; // slightly off without this offset
-
                         //instrument[tracknum].Reset(true); // seems to do nothing
 
                         // doing this for every note played is insane:
                         // try a fresh new instrument (RAM and GC spammy)
-                        //instrument[tracknum] = new SfxrSynth(); // shouldn't be required
+                        instrument[tracknum] = new SfxrSynth(); // shouldn't be required, but for some reason it is
                         // set the params to current track's instrument string
                         instrument[tracknum].parameters
                             .SetSettingsString(soundChip.ReadSound(songData.tracks[tracknum].sfxID).param);
 
 
                         // pitch shift the sound to the correct musical note frequency
-                        instrument[tracknum].parameters.startFrequency =
-                            noteStartFrequency[gotANote + noteFUDGE] + freqFUDGE;
+                        instrument[tracknum].parameters.startFrequency = noteStartFrequency[gotANote];
 
 
                         // maybe this will help

--- a/SDK/Engine/Chips/Audio/MusicChip.cs
+++ b/SDK/Engine/Chips/Audio/MusicChip.cs
@@ -48,9 +48,11 @@ namespace PixelVision8.Engine.Chips
         public float[] noteHZ; // a lookup table of all musical notes in Hz
 
         public float[] noteStartFrequency; // same, but for sfxr frequency 0..1 range
-        protected float noteTickS = 30.0f / 120.0f; // (30.0f/120.0f) = 120BPM eighth notes
-        protected float noteTickSEven;
+
+        protected float swingRhythmFactor = 1.0f;//0.7f;
+        protected float noteTickS = 15.0f / 120.0f; // (15.0f/120.0f) = 120BPM sixteenth notes
         protected float noteTickSOdd;
+        protected float noteTickSEven;
 
         public int preRenderBitrate = 44100; //48000; // should be 44100; FIXME TODO EXPERIMENTING W BUGFIX
 
@@ -72,8 +74,6 @@ namespace PixelVision8.Engine.Chips
 
         public SongData[] songs = new SongData[1];
 //        protected int songLoopCount = 0;
-
-        protected float swingRhythmFactor = 0.7f;
 
         protected float time;
 
@@ -213,7 +213,7 @@ namespace PixelVision8.Engine.Chips
             {
                 if (time >= nextBeatTimestamp)
                 {
-                    nextBeatTimestamp = time + noteTickSOdd;//(SequencerBeatNumber % 2 == 1 ? noteTickSOdd : noteTickSEven);
+                    nextBeatTimestamp = time + noteTickS;//(SequencerBeatNumber % 2 == 1 ? noteTickSOdd : noteTickSEven);
                     OnBeat();
                 }
 
@@ -429,7 +429,7 @@ namespace PixelVision8.Engine.Chips
 
         public void UpdateNoteTickLengths()
         {
-            noteTickS = 30.0f / ActiveTrackerData.speedInBPM; // (30.0f/120.0f) = 120BPM eighth notes [tempo]
+            noteTickS = 15.0f / ActiveTrackerData.speedInBPM; // (15.0f/120.0f) = 120BPM sixteenth notes
             noteTickSOdd = noteTickS * swingRhythmFactor; // small beat
             noteTickSEven = noteTickS * 2 - noteTickSOdd; // long beat
         }

--- a/SDK/Engine/Data/TrackerData.cs
+++ b/SDK/Engine/Data/TrackerData.cs
@@ -61,7 +61,7 @@ namespace PixelVision8.Engine
         public int speedInBPM
         {
             get => _speedInBPM;
-            set => _speedInBPM = MathHelper.Clamp(value, 60, 480);
+            set => _speedInBPM = MathHelper.Clamp(value, 1, 480);
         }
 
         /// <summary>


### PR DESCRIPTION
Fixed song exporting, adjusted in-game tempo again, and gave the Music Tool the ability to automatically scroll during playback. Fixes bounty [#4](https://github.com/PixelVision8/Bounties/issues/4) as well as issues #270, and #272.