### PR TITLE
Initial Proof of Concept checkin for using Roslyn (C# Compiler)

### DIFF
--- a/Disks/PixelVisionOS/System/Tools/WorkspaceTool/ProjectTemplate/code.cs
+++ b/Disks/PixelVisionOS/System/Tools/WorkspaceTool/ProjectTemplate/code.cs
@@ -1,0 +1,24 @@
+using PixelVision8.Engine.Chips; //Mandatory
+
+namespace PixelVisionRoslyn //Currently mandatory, should probably stay mandatory
+{
+	public class RoslynGameChip : GameChip // : currently mandatory. Could have the engine search for any class that inherits from GameChip eventually.
+	{
+		public override void Init()
+		{
+			BackgroundColor(7);
+			DrawText("Holy Carp, a compiled C# Game!", 1, 1, DrawMode.Tile, "large", 15);
+		}
+		
+		public override void Update(int timeDelta)
+		{
+			
+		}
+		
+		public override void Draw()
+		{
+			RedrawDisplay();
+			DrawText(fps.ToString() + " fps", 1, 2, DrawMode.Tile, "large", 15);
+		}
+	}
+}

--- a/Runners/DevRunnerCore/DevRunner.CoreDesktop.csproj
+++ b/Runners/DevRunnerCore/DevRunner.CoreDesktop.csproj
@@ -73,6 +73,7 @@
 
   <ItemGroup>
     <PackageReference Include="ICSharpCode.SharpZipLib.dll" Version="0.85.4.369" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.6.0" />
     <PackageReference Include="MoonSharp" Version="2.0.0" />
   </ItemGroup>
 

--- a/Runners/GameRunnerCore/GameRunner.CoreDesktop.csproj
+++ b/Runners/GameRunnerCore/GameRunner.CoreDesktop.csproj
@@ -71,6 +71,7 @@
 
   <ItemGroup>
     <PackageReference Include="ICSharpCode.SharpZipLib.dll" Version="0.85.4.369" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.6.0" />
     <PackageReference Include="MoonSharp" Version="2.0.0" />
   </ItemGroup>
 

--- a/Runners/GameRunnerCore/Runner/PixelVision8Runner.cs
+++ b/Runners/GameRunnerCore/Runner/PixelVision8Runner.cs
@@ -709,15 +709,19 @@ namespace PixelVision8.Runner
         {
             base.ConfigureEngine(metaData);
 
-            // Get a reference to the Lua game
-            var game = tmpEngine.GameChip as LuaGameChip;
+            if (!LuaMode)
+                return;
+            
+                // Get a reference to the Lua game
+                var game = tmpEngine.GameChip as LuaGameChip;
 
-            // Get the script
-            var luaScript = game.LuaScript;
+                // Get the script
+                var luaScript = game.LuaScript;
 
-            luaScript.Globals["EnableAutoRun"] = new Action<bool>(EnableAutoRun);
-            luaScript.Globals["EnableBackKey"] = new Action<bool>(EnableBackKey);
 
+                luaScript.Globals["EnableAutoRun"] = new Action<bool>(EnableAutoRun);
+                luaScript.Globals["EnableBackKey"] = new Action<bool>(EnableBackKey);
+            
 
             if (mode == RunnerMode.Playing)
             {

--- a/Runners/PixelVision8Core/PixelVision8.CoreDesktop.csproj
+++ b/Runners/PixelVision8Core/PixelVision8.CoreDesktop.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
@@ -76,6 +76,7 @@
 
   <ItemGroup>
     <PackageReference Include="ICSharpCode.SharpZipLib.dll" Version="0.85.4.369" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.6.0" />
     <PackageReference Include="MoonSharp" Version="2.0.0" />
   </ItemGroup>
 

--- a/Runners/PixelVision8Core/Runner/PixelVision8Runner.cs
+++ b/Runners/PixelVision8Core/Runner/PixelVision8Runner.cs
@@ -709,6 +709,8 @@ namespace PixelVision8.Runner
         {
             base.ConfigureEngine(metaData);
 
+            if (!LuaMode)
+                return; 
             // Get a reference to the Lua game
             var game = tmpEngine.GameChip as LuaGameChip;
 

--- a/SDK/Engine/PixelVisionEngine.cs
+++ b/SDK/Engine/PixelVisionEngine.cs
@@ -148,7 +148,8 @@ namespace PixelVision8.Engine
             // Reset the sprite counter on each frame
             GameChip.CurrentSprites = 0;
 
-            foreach (var chip in UpdateChips) chip.Update(timeDelta); //delta / 1000f);
+            foreach (var chip in UpdateChips)
+                chip.Update(timeDelta); //delta / 1000f);
         }
 
         /// <summary>
@@ -159,7 +160,8 @@ namespace PixelVision8.Engine
         /// <tocexclude />
         public virtual void Draw()
         {
-            foreach (var chip in DrawChips) chip.Draw();
+            foreach (var chip in DrawChips)
+                chip.Draw();
         }
 
         /// <summary>

--- a/SDK/Workspace/Services/WorkspaceService.cs
+++ b/SDK/Workspace/Services/WorkspaceService.cs
@@ -39,7 +39,8 @@ namespace PixelVision8.Runner.Services
             "lua",
             "json",
             "txt",
-            "wav"
+            "wav",
+            "cs"
         };
 
         protected WorkspacePath logFilePath;

--- a/UnitTests/UnitTests.csproj
+++ b/UnitTests/UnitTests.csproj
@@ -15,6 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.6.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />


### PR DESCRIPTION
This branch serves as a proof of concept that PixelVision8 can compile and run C# code instead of Lua for a GameChip. 

To see this run, start a new GameRunner.CoreDesktop instance from Visual Studio. It will run the Boot and Loader tools from Lua code, and then will compile code.cs from the DefaultGame folder and run it instead of the code.lua file. A green screen displaying a distinctly different initial message and a FPS counter will display instead of the usual "Empty Game" message found in the Lua file. 

Several enhancements are marked by TODOs. These were not necessary to prove the baseline concept, and mark how to add some important missing features this would need to enable C# to fully replace Lua. Most notably, these include displaying compiler errors to the user on a failure to compile and reading multiple C# files instead of a single one. I also indicated an enhancement that would potentially allow users to name their namespace/class anything they wanted, though I remain uncertain if that's the best plan versus mandating a specific namespace/class for the initial GameChip file. 

Additionally, the last bit of the CompileFromSource function could be used to load GameChips from pre-compiled DLLs. This is likely to be useful for the OS games, since compiling C# files is exactly as fast as compiling in Visual Studio (on my machine, this is a little over a second for the nearly-empty code.cs file as presented). The User is unlikely to enjoy a multi-second delay each time PixelVision8 changes disks, so this is probably a good plan if the system disks were to be ported to C#.  A project (System or otherwise, though I am fairly certain letting users send pre-compiled DLLs in a .pv8 file is a bad idea) with a GameChip to be compiled to .dll should just reference PixelVisionRunner.dll to access the GameChip class (and possibly underlying MonoGame/MonoVision libraries, to be determined)